### PR TITLE
refactor(ui): sidebar navigation overhaul and control monitor polish

### DIFF
--- a/src/components/dashboard/QCDashboard.tsx
+++ b/src/components/dashboard/QCDashboard.tsx
@@ -58,6 +58,7 @@ import { DISEASE_DEFINITIONS } from "@/constants/monitor-config";
 import { useQCLogic } from "@/hooks/useQCLogic";
 import { useToast } from "@/hooks/useToast";
 import { getUser, type AuthUser } from "@/lib/auth";
+import type { ControlTabSlug } from "@/constants/monitor-config";
 import {
   buildRunStatisticsSummary,
   DEFAULT_IN_HOUSE_LOT_NUMBER,
@@ -101,9 +102,7 @@ import { validateODValue } from "@/utils/export";
 interface QCDashboardProps {
   diseaseSlug: DiseaseSlug;
   controlType: ControlTypeSlug;
-  diseaseName: string;
-  controlName: string;
-  assayTag?: string;
+  controlTabSlug: ControlTabSlug;
 }
 
 type NewLotFormValues = {
@@ -422,9 +421,7 @@ function buildSparklinePath(points: { x: number; y: number }[]): string {
 export default function QCDashboard({
   diseaseSlug,
   controlType,
-  diseaseName,
-  controlName,
-  assayTag,
+  controlTabSlug,
 }: QCDashboardProps) {
   const navigate = useNavigate();
   const prefersReducedMotion = useReducedMotion();
@@ -500,7 +497,6 @@ export default function QCDashboard({
     ? selectedInHouseBatchId
     : selectedLotNumber;
   const currentCV = cvTrend.currentCV ?? 0;
-  const chartSubtitle = `${controlName.toUpperCase()} - ${diseaseName.toUpperCase()}${assayTag ? ` - ${assayTag}` : ""}`;
   const minRunsForWestgard = settings.minDataPointsForWestgard;
   const monitorStatus = getMonitorStatus(
     qcRules,
@@ -969,19 +965,7 @@ export default function QCDashboard({
 
   return (
     <div>
-      <motion.div
-        {...getRevealProps(0)}
-        className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"
-      >
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.05em] text-[#9ca3af]">
-            {chartSubtitle}
-          </p>
-          <h1 className="mt-2 text-[28px] font-bold text-[#111827]">{`${diseaseName} ${controlName}`}</h1>
-        </div>
-      </motion.div>
-
-      <motion.div {...getRevealProps(1)} className="qc-card mb-6 p-5">
+      <motion.div {...getRevealProps(0)} className="qc-card mb-6 p-5">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="flex-1">
             <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#6b7280]">
@@ -1071,19 +1055,14 @@ export default function QCDashboard({
       </motion.div>
 
       <motion.div
-        {...getRevealProps(2)}
+        {...getRevealProps(1)}
         className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3"
       >
         <div className="qc-card lg:col-span-2">
           <div className="mb-6 flex items-start justify-between gap-4">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-[#9ca3af]">
-                NEW QC ENTRY
-              </p>
-              <h2 className="mt-3 text-[18px] font-semibold text-[#111827]">
-                Record run details for this dataset
-              </h2>
-            </div>
+            <h2 className="text-[16px] font-semibold text-[#111827]">
+              New QC Entry
+            </h2>
           </div>
 
           {isArchivedDataset && (
@@ -1192,7 +1171,7 @@ export default function QCDashboard({
                     variant="outline"
                     className="h-11 w-full border-[#dbe4ff] text-[#1a1aff]"
                     onClick={() =>
-                      navigate(`/monitor/${nextDisease.slug}/${controlType}`)
+                      navigate(`/monitor/${nextDisease.slug}/${controlTabSlug}`)
                     }
                   >
                     {`Next disease -> ${nextDisease.name}`}
@@ -1235,7 +1214,7 @@ export default function QCDashboard({
       </motion.div>
 
       <motion.div
-        {...getRevealProps(3)}
+        {...getRevealProps(2)}
         className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-6"
       >
         {[
@@ -1281,7 +1260,7 @@ export default function QCDashboard({
       </motion.div>
 
       <motion.div
-        {...getRevealProps(4)}
+        {...getRevealProps(3)}
         className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3"
       >
         <div className="lg:col-span-2">
@@ -1429,7 +1408,7 @@ export default function QCDashboard({
         </div>
       </motion.div>
 
-      <motion.div {...getRevealProps(5)} className="qc-card">
+      <motion.div {...getRevealProps(4)} className="qc-card">
         <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h2 className="text-[16px] font-semibold text-[#111827]">
             Recent Control Runs

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,23 +1,26 @@
 import {
   ArrowRightIcon,
+  ArrowSquareOutIcon,
   BellIcon,
   CaretDownIcon,
   ChartBarIcon,
   ClockIcon,
   GearIcon,
   SignOutIcon,
+  StackIcon,
   VirusIcon,
   WarningIcon,
 } from "@phosphor-icons/react";
+import { Collapsible } from "radix-ui";
 import { AnimatePresence, motion, type Transition } from "framer-motion";
 import * as React from "react";
 import { createPortal } from "react-dom";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { DISEASE_DEFINITIONS } from "@/constants/monitor-config";
 import { useAuth } from "@/hooks/useAuth";
 import { getAllViolations } from "@/lib/qcStorage";
-import type { ControlTypeSlug, DiseaseSlug } from "@/types/qc.types";
+import type { DiseaseSlug } from "@/types/qc.types";
 import { cn } from "@/utils/cn";
 
 import {
@@ -76,12 +79,6 @@ const DISEASE_ROUTE_CONFIG: DiseaseRouteConfig[] = [
   { slug: "dengue", name: "Dengue", icon: VirusIcon },
 ];
 
-const CONTROL_LINKS: { slug: ControlTypeSlug; label: string }[] = [
-  { slug: "in-house-control", label: "In-house" },
-  { slug: "positive-control", label: "Positive" },
-  { slug: "negative-control", label: "Negative" },
-];
-
 const SYSTEM_ROUTES: SystemRoute[] = [
   { href: "/history", icon: ClockIcon, label: "History" },
   { href: "/violations", icon: WarningIcon, label: "Violations" },
@@ -111,16 +108,10 @@ const SIDEBAR_TRANSITION: Transition = {
 
 const FLYOUT_LEFT = 76;
 const FLYOUT_WIDTH = 244;
-const FLYOUT_HEIGHT = 198;
+const FLYOUT_HEIGHT = 280;
 const FLYOUT_ANIMATION: Transition = {
   duration: 0.15,
   ease: [0.4, 0, 0.2, 1],
-};
-
-type FloatingDiseaseState = {
-  disease: DiseaseRouteConfig;
-  displayName: string;
-  top: number;
 };
 
 function getActiveDisease(pathname: string): DiseaseSlug | null {
@@ -134,17 +125,6 @@ function getActiveDisease(pathname: string): DiseaseSlug | null {
   return DISEASE_ROUTE_CONFIG.some((disease) => disease.slug === slug)
     ? slug
     : null;
-}
-
-function getActiveControl(pathname: string): ControlTypeSlug | null {
-  const match = pathname.match(/^\/monitor\/[^/]+\/([^/]+)/);
-
-  if (match === null) {
-    return null;
-  }
-
-  const slug = match[1] as ControlTypeSlug;
-  return CONTROL_LINKS.some((control) => control.slug === slug) ? slug : null;
 }
 
 function SidebarTooltip({
@@ -239,16 +219,12 @@ function getFlyoutTop(triggerRect: DOMRect): number {
 export function AppSidebar() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { open, isMobile, setOpenMobile } = useSidebar();
+  const { open, isMobile, setOpenMobile, toggleSidebar } = useSidebar();
   const { user, signOut } = useAuth();
   const [mounted, setMounted] = React.useState(false);
   const [openViolationCount, setOpenViolationCount] = React.useState(0);
   const activeDisease = getActiveDisease(location.pathname);
-  const activeControl = getActiveControl(location.pathname);
-  const [expandedDisease, setExpandedDisease] =
-    React.useState<DiseaseSlug | null>(activeDisease);
-  const [floatingDisease, setFloatingDisease] =
-    React.useState<FloatingDiseaseState | null>(null);
+  const [diseasesFlyoutTop, setDiseasesFlyoutTop] = React.useState<number | null>(null);
   const showFlyoutTimer = React.useRef<number | null>(null);
   const hideFlyoutTimer = React.useRef<number | null>(null);
 
@@ -296,12 +272,8 @@ export function AppSidebar() {
   }, [location.pathname]);
 
   React.useEffect(() => {
-    setExpandedDisease(activeDisease);
-  }, [activeDisease]);
-
-  React.useEffect(() => {
     if (open || isMobile) {
-      setFloatingDisease(null);
+      setDiseasesFlyoutTop(null);
     }
   }, [isMobile, open]);
 
@@ -329,31 +301,21 @@ export function AppSidebar() {
     }
   };
 
-  const closeFloatingDisease = () => {
+  const closeDiseasesFlyout = () => {
     clearFlyoutTimers();
-    setFloatingDisease(null);
+    setDiseasesFlyoutTop(null);
   };
 
-  const openFloatingDisease = (
-    disease: DiseaseRouteConfig,
-    displayName: string,
-    triggerElement: HTMLElement,
-    delay = 100,
-  ) => {
+  const openDiseasesFlyout = (triggerElement: HTMLElement, delay = 100) => {
     clearFlyoutTimers();
 
     showFlyoutTimer.current = window.setTimeout(() => {
       const triggerRect = triggerElement.getBoundingClientRect();
-
-      setFloatingDisease({
-        disease,
-        displayName,
-        top: getFlyoutTop(triggerRect),
-      });
+      setDiseasesFlyoutTop(getFlyoutTop(triggerRect));
     }, delay);
   };
 
-  const scheduleFloatingDiseaseClose = () => {
+  const scheduleDiseasesFlyoutClose = () => {
     if (showFlyoutTimer.current !== null) {
       window.clearTimeout(showFlyoutTimer.current);
       showFlyoutTimer.current = null;
@@ -364,27 +326,8 @@ export function AppSidebar() {
     }
 
     hideFlyoutTimer.current = window.setTimeout(() => {
-      setFloatingDisease(null);
+      setDiseasesFlyoutTop(null);
     }, 120);
-  };
-
-  const handleDiseaseToggle = (disease: DiseaseSlug) => {
-    setExpandedDisease((currentDisease) =>
-      currentDisease === disease ? null : disease,
-    );
-  };
-
-  const handleDiseaseButtonClick = (
-    disease: DiseaseRouteConfig,
-    displayName: string,
-    event: React.MouseEvent<HTMLButtonElement>,
-  ) => {
-    if (!open && !isMobile) {
-      openFloatingDisease(disease, displayName, event.currentTarget, 0);
-      return;
-    }
-
-    handleDiseaseToggle(disease.slug);
   };
 
   const handleSidebarNavigate = (href: string) => {
@@ -410,7 +353,6 @@ export function AppSidebar() {
   const currentRole = user?.role ?? "Analyst";
   const currentUserInitials = user?.initials ?? "QC";
   const isCollapsedDesktop = !open && !isMobile;
-  const floatingDiseaseSlug = floatingDisease?.disease.slug ?? null;
 
   const accountMenuItems: Array<{
     label: string;
@@ -558,165 +500,155 @@ export function AppSidebar() {
 
         <SidebarContent>
           <SidebarGroup>
-            <SidebarGroupLabel>DISEASE LIST</SidebarGroupLabel>
+            <SidebarGroupLabel>SURVEILLANCE PROGRAMS</SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu>
-                {DISEASE_ROUTE_CONFIG.map((disease) => {
-                  const Icon = disease.icon;
-                  const isCurrentDisease = activeDisease === disease.slug;
-                  const isOpen = expandedDisease === disease.slug;
-                  const diseaseDisplayName =
-                    DISEASE_DEFINITIONS.find(
-                      (item) => item.slug === disease.slug,
-                    )?.name ?? disease.name;
-                  const diseaseAccent = DISEASE_ACCENTS[disease.slug];
-                  const diseaseMenuButton = (
+              {isCollapsedDesktop ? (
+                // Collapsed icon mode: one icon per section
+                <SidebarMenu>
+                  {/* Diseases — hover for flyout, click to expand */}
+                  <SidebarMenuItem>
                     <SidebarMenuButton
                       type="button"
-                      isActive={isCurrentDisease && !isCollapsedDesktop}
-                      title={diseaseDisplayName}
-                      aria-expanded={
-                        isCollapsedDesktop
-                          ? floatingDiseaseSlug === disease.slug
-                          : isOpen
+                      isActive={false}
+                      onMouseEnter={(event) =>
+                        openDiseasesFlyout(event.currentTarget)
                       }
-                      onClick={(event) =>
-                        handleDiseaseButtonClick(
-                          disease,
-                          diseaseDisplayName,
-                          event,
-                        )
-                      }
-                      onMouseEnter={(event) => {
-                        if (isCollapsedDesktop) {
-                          openFloatingDisease(
-                            disease,
-                            diseaseDisplayName,
-                            event.currentTarget,
-                          );
-                        }
-                      }}
-                      onMouseLeave={() => {
-                        if (isCollapsedDesktop) {
-                          scheduleFloatingDiseaseClose();
-                        }
-                      }}
+                      onMouseLeave={scheduleDiseasesFlyoutClose}
+                      onClick={toggleSidebar}
                       className={cn(
-                        isCollapsedDesktop &&
-                          "mx-auto h-10 w-10 rounded-lg p-0",
-                        isCollapsedDesktop &&
-                          isCurrentDisease &&
-                          "bg-[#eff6ff] text-[var(--sidebar-accent-foreground)] hover:bg-[#eff6ff]",
-                        !isCollapsedDesktop && "justify-between",
+                        "mx-auto h-10 w-10 rounded-lg p-0",
+                        activeDisease !== null &&
+                          "bg-[#eff6ff] hover:bg-[#eff6ff]",
                       )}
                     >
-                      {isCollapsedDesktop ? (
-                        <span
-                          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
-                          style={
-                            isCurrentDisease
-                              ? {
-                                  color: diseaseAccent,
-                                  boxShadow: `0 0 0 2px #ffffff, 0 0 0 3px ${diseaseAccent}`,
-                                }
-                              : { color: "#334155" }
-                          }
-                        >
-                          <Icon size={17} />
-                        </span>
-                      ) : (
-                        <span className="flex min-w-0 flex-1 items-center">
-                          <Icon size={17} className="shrink-0" />
-                          <SidebarAnimatedLabel className="ml-2 flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap [--sidebar-label-width:11rem]">
-                            <span className="truncate">
-                              {diseaseDisplayName}
-                            </span>
-                          </SidebarAnimatedLabel>
-                        </span>
-                      )}
-                      {!isCollapsedDesktop ? (
-                        <span className="ml-auto flex h-4 w-4 flex-none items-center justify-center">
-                          <CaretDownIcon
-                            size={16}
-                            className={cn(
-                              "h-4 w-4 flex-none origin-center transition-transform duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]",
-                              isOpen && "rotate-180",
-                            )}
-                          />
-                        </span>
-                      ) : null}
+                      <span
+                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+                        style={{
+                          color:
+                            activeDisease !== null
+                              ? DISEASE_ACCENTS[activeDisease]
+                              : "#334155",
+                        }}
+                      >
+                        <VirusIcon size={17} />
+                      </span>
                     </SidebarMenuButton>
-                  );
+                  </SidebarMenuItem>
 
-                  return (
-                    <SidebarMenuItem key={disease.slug}>
-                      {isCollapsedDesktop ? (
-                        diseaseMenuButton
-                      ) : (
-                        <SidebarTooltip label={diseaseDisplayName}>
-                          {diseaseMenuButton}
-                        </SidebarTooltip>
-                      )}
+                  {/* Exports — placeholder */}
+                  <SidebarMenuItem>
+                    <SidebarTooltip label="Exports">
+                      <SidebarMenuButton
+                        type="button"
+                        isActive={false}
+                        className="mx-auto h-10 w-10 rounded-lg p-0 opacity-40"
+                      >
+                        <ArrowSquareOutIcon size={17} className="text-[#334155]" />
+                      </SidebarMenuButton>
+                    </SidebarTooltip>
+                  </SidebarMenuItem>
 
-                      <AnimatePresence initial={false}>
-                        {isOpen && (open || isMobile) ? (
-                          <motion.div
-                            key="submenu"
-                            initial={{ height: 0, opacity: 0 }}
-                            animate={{
-                              height: "auto",
-                              opacity: 1,
-                              transition: {
-                                height: SIDEBAR_TRANSITION,
-                                opacity: { duration: 0.2, delay: 0.05 },
-                              },
-                            }}
-                            exit={{
-                              height: 0,
-                              opacity: 0,
-                              transition: {
-                                height: {
-                                  duration: 0.2,
-                                  ease: [0.4, 0, 0.2, 1],
-                                },
-                                opacity: { duration: 0.1 },
-                              },
-                            }}
-                            style={{ overflow: "hidden" }}
-                          >
-                            <SidebarMenuSub>
-                              {CONTROL_LINKS.map((control) => {
-                                const href = `/monitor/${disease.slug}/${control.slug}`;
-                                const isActive =
-                                  isCurrentDisease &&
-                                  activeControl === control.slug;
+                  {/* Batches / Lots — placeholder */}
+                  <SidebarMenuItem>
+                    <SidebarTooltip label="Batches / Lots">
+                      <SidebarMenuButton
+                        type="button"
+                        isActive={false}
+                        className="mx-auto h-10 w-10 rounded-lg p-0 opacity-40"
+                      >
+                        <StackIcon size={17} className="text-[#334155]" />
+                      </SidebarMenuButton>
+                    </SidebarTooltip>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              ) : (
+                // Expanded mode: collapsible structure
+                <SidebarMenu>
+                  {/* Diseases — open by default */}
+                  <SidebarMenuItem>
+                    <Collapsible.Root className="group/diseases w-full" defaultOpen>
+                      <Collapsible.Trigger asChild>
+                        <SidebarMenuButton type="button">
+                          <VirusIcon size={17} className="shrink-0" />
+                          <span className="flex min-w-0 flex-1 items-center justify-between">
+                            <span className="truncate">Diseases</span>
+                            <CaretDownIcon
+                              size={13}
+                              className="shrink-0 transition-transform duration-200 group-data-[state=open]/diseases:rotate-180"
+                            />
+                          </span>
+                        </SidebarMenuButton>
+                      </Collapsible.Trigger>
+                      <Collapsible.Content>
+                        <SidebarMenuSub>
+                          {DISEASE_ROUTE_CONFIG.map((disease) => {
+                            const diseaseDisplayName =
+                              DISEASE_DEFINITIONS.find(
+                                (item) => item.slug === disease.slug,
+                              )?.name ?? disease.name;
+                            const isCurrentDisease =
+                              activeDisease === disease.slug;
 
-                                return (
-                                  <SidebarMenuSubItem key={control.slug}>
-                                    <SidebarMenuSubButton
-                                      asChild
-                                      isActive={isActive}
-                                    >
-                                      <Link
-                                        to={href}
-                                        onClick={() =>
-                                          isMobile && setOpenMobile(false)
-                                        }
-                                      >
-                                        {control.label}
-                                      </Link>
-                                    </SidebarMenuSubButton>
-                                  </SidebarMenuSubItem>
-                                );
-                              })}
-                            </SidebarMenuSub>
-                          </motion.div>
-                        ) : null}
-                      </AnimatePresence>
-                    </SidebarMenuItem>
-                  );
-                })}
-              </SidebarMenu>
+                            return (
+                              <SidebarMenuSubItem key={disease.slug}>
+                                <SidebarMenuSubButton
+                                  type="button"
+                                  isActive={isCurrentDisease}
+                                  onClick={() =>
+                                    handleSidebarNavigate(
+                                      `/monitor/${disease.slug}/in-house`,
+                                    )
+                                  }
+                                >
+                                  {diseaseDisplayName}
+                                </SidebarMenuSubButton>
+                              </SidebarMenuSubItem>
+                            );
+                          })}
+                        </SidebarMenuSub>
+                      </Collapsible.Content>
+                    </Collapsible.Root>
+                  </SidebarMenuItem>
+
+                  {/* Exports — empty placeholder */}
+                  <SidebarMenuItem>
+                    <Collapsible.Root className="group/exports w-full">
+                      <Collapsible.Trigger asChild>
+                        <SidebarMenuButton type="button">
+                          <ArrowSquareOutIcon size={17} className="shrink-0" />
+                          <span className="flex min-w-0 flex-1 items-center justify-between">
+                            <span className="truncate">Exports</span>
+                            <CaretDownIcon
+                              size={13}
+                              className="shrink-0 transition-transform duration-200 group-data-[state=open]/exports:rotate-180"
+                            />
+                          </span>
+                        </SidebarMenuButton>
+                      </Collapsible.Trigger>
+                      <Collapsible.Content />
+                    </Collapsible.Root>
+                  </SidebarMenuItem>
+
+                  {/* Batches / Lots — empty placeholder */}
+                  <SidebarMenuItem>
+                    <Collapsible.Root className="group/batches w-full">
+                      <Collapsible.Trigger asChild>
+                        <SidebarMenuButton type="button">
+                          <StackIcon size={17} className="shrink-0" />
+                          <span className="flex min-w-0 flex-1 items-center justify-between">
+                            <span className="truncate">Batches / Lots</span>
+                            <CaretDownIcon
+                              size={13}
+                              className="shrink-0 transition-transform duration-200 group-data-[state=open]/batches:rotate-180"
+                            />
+                          </span>
+                        </SidebarMenuButton>
+                      </Collapsible.Trigger>
+                      <Collapsible.Content />
+                    </Collapsible.Root>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              )}
             </SidebarGroupContent>
           </SidebarGroup>
 
@@ -821,22 +753,23 @@ export function AppSidebar() {
         ? null
         : createPortal(
             <AnimatePresence initial={false}>
-              {floatingDisease !== null && isCollapsedDesktop ? (
+              {diseasesFlyoutTop !== null && isCollapsedDesktop ? (
                 <>
+                  {/* Invisible bridge keeps the flyout alive as the mouse moves from icon to panel */}
                   <div
                     aria-hidden="true"
                     className="fixed z-40"
                     style={{
                       left: 58,
-                      top: floatingDisease.top,
+                      top: diseasesFlyoutTop,
                       width: FLYOUT_LEFT - 58,
                       height: FLYOUT_HEIGHT,
                     }}
                     onMouseEnter={clearFlyoutTimers}
-                    onMouseLeave={scheduleFloatingDiseaseClose}
+                    onMouseLeave={scheduleDiseasesFlyoutClose}
                   />
                   <motion.div
-                    key={floatingDisease.disease.slug}
+                    key="diseases-flyout"
                     initial={{ opacity: 0, x: -8, scale: 0.96 }}
                     animate={{ opacity: 1, x: 0, scale: 1 }}
                     exit={{ opacity: 0, x: -8, scale: 0.96 }}
@@ -844,54 +777,58 @@ export function AppSidebar() {
                     className="fixed z-50 overflow-hidden rounded-2xl border border-[#e5e7eb] bg-white p-2 shadow-[0_18px_45px_rgba(15,23,42,0.16)]"
                     style={{
                       left: FLYOUT_LEFT,
-                      top: floatingDisease.top,
+                      top: diseasesFlyoutTop,
                       width: FLYOUT_WIDTH,
                       transformOrigin: "left center",
                     }}
                     onMouseEnter={clearFlyoutTimers}
-                    onMouseLeave={scheduleFloatingDiseaseClose}
+                    onMouseLeave={scheduleDiseasesFlyoutClose}
                   >
-                    <div className="flex items-center gap-3 px-3 py-2.5">
-                      <span
-                        className="inline-flex h-7 min-w-10 items-center justify-center rounded-lg px-2 text-[11px] font-bold tracking-[0.08em] text-white"
-                        style={{
-                          backgroundColor:
-                            DISEASE_ACCENTS[floatingDisease.disease.slug],
-                        }}
-                      >
-                        {DISEASE_BADGES[floatingDisease.disease.slug]}
-                      </span>
-                      <span className="min-w-0 truncate text-sm font-semibold text-[#111827]">
-                        {floatingDisease.displayName}
-                      </span>
+                    <div className="px-3 py-2">
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#9ca3af]">
+                        Diseases
+                      </p>
                     </div>
-                    <div className="mx-3 h-px bg-[#e5e7eb]" />
-                    <div className="py-2">
-                      {CONTROL_LINKS.map((control) => {
-                        const href = `/monitor/${floatingDisease.disease.slug}/${control.slug}`;
-                        const isActiveControl =
-                          activeDisease === floatingDisease.disease.slug &&
-                          activeControl === control.slug;
+                    <div className="mx-3 mb-1 h-px bg-[#e5e7eb]" />
+                    <div className="py-1">
+                      {DISEASE_ROUTE_CONFIG.map((disease) => {
+                        const diseaseDisplayName =
+                          DISEASE_DEFINITIONS.find(
+                            (item) => item.slug === disease.slug,
+                          )?.name ?? disease.name;
+                        const isCurrentDisease = activeDisease === disease.slug;
 
                         return (
                           <button
-                            key={control.slug}
+                            key={disease.slug}
                             type="button"
                             onClick={() => {
-                              navigate(href);
-                              closeFloatingDisease();
+                              navigate(
+                                `/monitor/${disease.slug}/in-house`,
+                              );
+                              closeDiseasesFlyout();
                             }}
                             className={cn(
-                              "group/flyout flex h-10 w-full items-center justify-between rounded-xl px-3 text-left text-sm font-medium transition-colors",
-                              isActiveControl
+                              "group/flyout-item flex h-9 w-full items-center gap-2.5 rounded-xl px-3 text-left text-sm font-medium transition-colors",
+                              isCurrentDisease
                                 ? "bg-[#eff6ff] text-[var(--brand-blue)]"
-                                : "text-[#475569] hover:bg-[#f8fafc] hover:text-[var(--brand-blue)]",
+                                : "text-[#475569] hover:bg-[#f8fafc] hover:text-[#111827]",
                             )}
                           >
-                            <span>{control.label} Control</span>
+                            <span
+                              className="inline-flex h-5 min-w-8 shrink-0 items-center justify-center rounded-md px-1.5 text-[10px] font-bold tracking-[0.06em] text-white"
+                              style={{
+                                backgroundColor: DISEASE_ACCENTS[disease.slug],
+                              }}
+                            >
+                              {DISEASE_BADGES[disease.slug]}
+                            </span>
+                            <span className="flex-1 truncate">
+                              {diseaseDisplayName}
+                            </span>
                             <ArrowRightIcon
-                              size={15}
-                              className="opacity-0 transition-opacity group-hover/flyout:opacity-100"
+                              size={13}
+                              className="shrink-0 opacity-0 transition-opacity group-hover/flyout-item:opacity-50"
                             />
                           </button>
                         );

--- a/src/components/layout/DashboardHeader.tsx
+++ b/src/components/layout/DashboardHeader.tsx
@@ -2,7 +2,11 @@ import { BellIcon, QuestionIcon } from '@phosphor-icons/react';
 import * as React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
-import { getControlDefinition, getDiseaseDefinition } from '@/constants/monitor-config';
+import {
+  controlTabSlugToType,
+  getControlDefinition,
+  getDiseaseDefinition,
+} from '@/constants/monitor-config';
 import { getAllViolations } from '@/lib/qcStorage';
 
 import {
@@ -25,8 +29,10 @@ function formatControlLabel(slug: string | undefined): string | null {
   if (slug === undefined) {
     return null;
   }
-
-  return getControlDefinition(slug)?.label.toUpperCase() ?? null;
+  const controlTypeSlug = controlTabSlugToType(slug);
+  return controlTypeSlug
+    ? (getControlDefinition(controlTypeSlug)?.label.toUpperCase() ?? null)
+    : null;
 }
 
 function buildSegments(pathname: string): BreadcrumbSegment[] {

--- a/src/constants/monitor-config.ts
+++ b/src/constants/monitor-config.ts
@@ -246,6 +246,28 @@ const MONITOR_SEEDS: Record<DiseaseSlug, Record<ControlSlug, MonitorSeed>> = {
   },
 };
 
+export type ControlTabSlug = 'in-house' | 'positive' | 'negative';
+
+const CONTROL_TAB_TO_TYPE: Record<ControlTabSlug, ControlSlug> = {
+  'in-house': 'in-house-control',
+  positive: 'positive-control',
+  negative: 'negative-control',
+};
+
+const CONTROL_TYPE_TO_TAB: Record<ControlSlug, ControlTabSlug> = {
+  'in-house-control': 'in-house',
+  'positive-control': 'positive',
+  'negative-control': 'negative',
+};
+
+export function controlTabSlugToType(slug: string): ControlSlug | null {
+  return (CONTROL_TAB_TO_TYPE as Record<string, ControlSlug>)[slug] ?? null;
+}
+
+export function controlTypeToTabSlug(slug: ControlSlug): ControlTabSlug {
+  return CONTROL_TYPE_TO_TAB[slug];
+}
+
 export const getDiseaseDefinition = (slug: string | undefined): DiseaseDefinition | undefined =>
   DISEASE_DEFINITIONS.find((disease) => disease.slug === slug);
 

--- a/src/pages/ControlMonitor.tsx
+++ b/src/pages/ControlMonitor.tsx
@@ -1,29 +1,71 @@
-import { Navigate, useParams } from "react-router-dom";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
 
-import QCDashboard from "@/components/dashboard/QCDashboard";
 import {
-  getControlDefinition,
+  CONTROL_DEFINITIONS,
+  controlTabSlugToType,
   getDiseaseDefinition,
 } from "@/constants/monitor-config";
+import type { ControlTabSlug } from "@/constants/monitor-config";
+import QCDashboard from "@/components/dashboard/QCDashboard";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const CONTROL_TABS: { slug: ControlTabSlug; label: string }[] = [
+  { slug: "in-house", label: "In-house" },
+  { slug: "positive", label: "Positive" },
+  { slug: "negative", label: "Negative" },
+];
 
 export function ControlMonitor() {
+  const navigate = useNavigate();
   const { disease, control } = useParams();
 
   const diseaseConfig = getDiseaseDefinition(disease);
-  const controlConfig = getControlDefinition(control);
+  const controlTypeSlug = controlTabSlugToType(control ?? "");
+  const controlConfig = controlTypeSlug
+    ? CONTROL_DEFINITIONS.find((c) => c.slug === controlTypeSlug)
+    : undefined;
 
-  if (!diseaseConfig || !controlConfig) {
+  if (!diseaseConfig || !controlConfig || !controlTypeSlug) {
     return <Navigate to="/monitor" replace />;
   }
 
+  const tabSlug = control as ControlTabSlug;
+  const chartSubtitle = `${controlConfig.label.toUpperCase()} - ${diseaseConfig.name.toUpperCase()}${diseaseConfig.assayTag ? ` - ${diseaseConfig.assayTag}` : ""}`;
+
   return (
-    <QCDashboard
-      key={`${diseaseConfig.slug}-${controlConfig.slug}`}
-      diseaseSlug={diseaseConfig.slug}
-      controlType={controlConfig.slug}
-      diseaseName={diseaseConfig.name}
-      controlName={controlConfig.label}
-      assayTag={diseaseConfig.assayTag}
-    />
+    <div>
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.05em] text-[#9ca3af]">
+            {chartSubtitle}
+          </p>
+          <h1 className="mt-2 text-[28px] font-bold text-[#111827]">
+            {`${diseaseConfig.name} ${controlConfig.label}`}
+          </h1>
+        </div>
+
+        <Tabs
+          value={tabSlug}
+          onValueChange={(value) =>
+            navigate(`/monitor/${diseaseConfig.slug}/${value}`)
+          }
+        >
+          <TabsList>
+            {CONTROL_TABS.map((tab) => (
+              <TabsTrigger key={tab.slug} value={tab.slug}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      <QCDashboard
+        key={`${diseaseConfig.slug}-${controlTypeSlug}`}
+        diseaseSlug={diseaseConfig.slug}
+        controlType={controlTypeSlug}
+        controlTabSlug={tabSlug}
+      />
+    </div>
   );
 }

--- a/src/pages/DiseaseOverview.tsx
+++ b/src/pages/DiseaseOverview.tsx
@@ -12,6 +12,7 @@ import {
   entriesToChartData,
   getControlParameters,
 } from "@/lib/qcMonitor";
+import { controlTypeToTabSlug } from "@/constants/monitor-config";
 import { getEntries, getInHouseBatches, getLots } from "@/lib/qcStorage";
 import type {
   ChartDataPoint,
@@ -225,7 +226,7 @@ export function DiseaseOverview() {
               />
 
               <Link
-                to={`/monitor/${diseaseConfig.slug}/${control.slug}`}
+                to={`/monitor/${diseaseConfig.slug}/${controlTypeToTabSlug(control.slug)}`}
                 className="inline-flex items-center gap-2 text-sm font-bold text-[#0000FF]"
               >
                 Open control monitor

--- a/src/pages/DiseaseSelector.tsx
+++ b/src/pages/DiseaseSelector.tsx
@@ -165,13 +165,6 @@ export function DiseaseSelector() {
       <motion.div className="mb-10" variants={headerVariants}>
         <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0">
-            <motion.p
-              variants={textRevealVariants}
-              className="mb-4 text-xs font-bold uppercase tracking-[0.35em]"
-              style={{ color: "#0000FF" }}
-            >
-              Real-Time Quality Control
-            </motion.p>
             <div className="overflow-hidden pb-1">
               <motion.h1
                 variants={textRevealVariants}


### PR DESCRIPTION
- Rename ASSAYS → SURVEILLANCE PROGRAMS with collapsible sections (Diseases, Exports, Batches / Lots); Diseases open by default
- Collapsed sidebar: show one icon per section instead of 5 disease icons — hover Diseases for flyout list, click to expand sidebar
- Tabs: move inline with page header (right-aligned on lg
- New QC Entry card: remove subtitle, normalize title to match other cards